### PR TITLE
Add more info to the README: compatible devices, bypass device scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # J7-C_UC96_BLE_Logger
-Bluetooth Low Energy Data logging for J7-C/UC96 USB Digital Power Testers
+Bluetooth Low Energy Data logging for J7-C/UC96 USB Digital Power Testers. It should work with all the digital testers sharing the atorch protocol - see [here](https://github.com/CursedHardware/atorch-console/blob/master/README.md#supported-meter) for a list of potentially supported devices. Tested on J7-C and UD18 meters.
 
 ## Installation
 
@@ -7,7 +7,7 @@ Requires [gattlib](https://github.com/labapart/gattlib).
 
 ### Warning
 
-Sadly there has been an API change with newer bluetooth adapters (HCI5) which [isn't supported by gattlib yet](https://github.com/oscaracena/pygattlib/issues/31). If you see a `Set scan parameters failed` error, your adapter may be using >=HCI5 and not be supported until the code has been ported to dbus/bluez or gattlib is updated.
+Sadly there has been an API change with newer bluetooth adapters (HCI5) which [isn't supported by gattlib yet](https://github.com/oscaracena/pygattlib/issues/31). If you see a `Set scan parameters failed` error, your adapter may be using >=HCI5 and not be supported until the code has been ported to dbus/bluez or gattlib is updated. You can still run the script, though, you just need to bypass the scan by passing the `--device` option (or its shorthand `-d`) when running it.
 
 ## Usage
 
@@ -33,7 +33,7 @@ Device control:
                         target device MAC address. If no address is given
                         the first compatible device found will be used
   -w, --wait            wait for device to appear
-  -r, --reconnect       wait and reconnect when loosing connection
+  -r, --reconnect       wait and reconnect after losing connection
   -H HCI, --hci HCI     HCI used for communication. Defaults to hci0
   -T SCANTIME, --scantime SCANTIME
                         Time in seconds to scan for devices. Defaults to 2

--- a/j7c.py
+++ b/j7c.py
@@ -25,7 +25,7 @@ group_debug_me.add_argument("-q", "--quiet", help="suppress non-data output mess
 group_dev = parser.add_argument_group(title="Device control")
 group_dev.add_argument("-d", "--device", help="target device MAC address. If no address is given the first compatible device found will be used", default=False)
 group_dev.add_argument('-w', '--wait', help='wait for device to appear', action='store_true')
-group_dev.add_argument('-r', '--reconnect', help='wait and reconnect when loosing connection', action='store_true')
+group_dev.add_argument('-r', '--reconnect', help='wait and reconnect after losing connection', action='store_true')
 group_dev.add_argument("-H", "--hci", help="HCI used for communication. Defaults to hci0", default="hci0")
 group_dev.add_argument("-T", "--scantime", help="Time in seconds to scan for devices. Defaults to 2 Seconds", default=2, type=int)
 
@@ -168,7 +168,7 @@ class ReceiveNotification(object):
         self.requester = NotifyRequester(self.received, address, False)
 
     def connect(self):
-        debug(1, "Conneting to " + target)
+        debug(1, "Connecting to " + target)
         sys.stdout.flush()
 
         self.requester.connect(True)
@@ -210,7 +210,7 @@ while doWait:
                     debug(3, "Found compatible device at address " + address)
                     target = address
         except:
-            debug(0, "Device discovery failed. Is bluetooth enabled? Are you root?")
+            debug(0, "Device discovery failed. Is bluetooth enabled? Are you root? Try running the script with the --device option to bypass the scan - see https://github.com/adlerweb/J7-C_UC96_BLE_Logger/blob/main/README.md#warning")
 
     if args.wait:
         doWait = True


### PR DESCRIPTION
- Added a note about other potentially compatible devices than the J7-C, sharing the same BLE protocol. Tested on UD18 meter - it works perfectly.
- Clarified the extent of the [warning](https://github.com/adlerweb/J7-C_UC96_BLE_Logger/tree/main?tab=readme-ov-file#warning): the issue can be bypassed by identifying the MAC address of the device in advance, and passing that as an argument when running the script.
- Fixed some typos.