### PR TITLE
added docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM debian:bullseye-slim
+
+RUN apt-get update && apt-get install --yes git python3-gattlib && apt-get clean
+
+COPY j7c.py /j7c.py
+
+ENTRYPOINT ["python3", "/j7c.py"]

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Output options for RAW:
   --raw-pretty          Use pretty-print for RAW Output
 ```
 
+## Docker
+
+The command can be run via docker or docker compose in case you have trouble installing the dependencies. Note that the container needs to run in privileged mode!
+
+  docker build . -t j7c
+  docker run -i --rm --net=host --privileged -v /dev:/dev j7c --help
+
 ## More
 
 The decoder was reverse engineered by myself. There are now a few more comprehensive protocol descriptions available, so if you want to work with these devices yourself you might want to have a look over there:


### PR DESCRIPTION
I couldn't get gattlib to compile on a modern python, so I whipped up a Docker container to run this via a slightly older Debian version.